### PR TITLE
Remove token being passed in from registration controller

### DIFF
--- a/backend/src/main/java/com/codify/backend/controller/RegistrationController.java
+++ b/backend/src/main/java/com/codify/backend/controller/RegistrationController.java
@@ -25,8 +25,7 @@ public class RegistrationController {
 				user.getUsername(),
 				user.getRoles().stream()
 				    .map(Enum::name)
-				    .collect(Collectors.toSet()),
-				"fake-token-blahblah"
+				    .collect(Collectors.toSet())
 			);
 		return ResponseEntity.ok(response);
 	}

--- a/backend/src/main/java/com/codify/backend/dto/RegistrationResponse.java
+++ b/backend/src/main/java/com/codify/backend/dto/RegistrationResponse.java
@@ -4,6 +4,5 @@ import java.util.Set;
 
 public record RegistrationResponse(
 	String username, 
-	Set<String> roles,
-	String token
+	Set<String> roles
 ){}


### PR DESCRIPTION
Removed the token being passed in to the RegistrationRequest for simplicity purposes. This will be updated in the future to automatically give the user a token once they successfully register.